### PR TITLE
fix: restore Tailwind empty-state markup lost during PR conflict reso…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -254,10 +254,16 @@ export default function Home() {
             )
           )}
       </div>
+
+      {/* Pagination / Empty state */}
       {!loading && dataList?.length <= 0 ? (
-        <Typography variant="h5" align="center">
-          No Results
-        </Typography>
+        <div className="flex flex-col items-center gap-2 py-16 text-center">
+          <Search className="h-12 w-12 text-navy-textSecondary dark:text-navyDark-textSecondary" aria-hidden="true" />
+          <h3 className="text-xl font-semibold text-navy-textPrimary dark:text-navyDark-textPrimary">No Results</h3>
+          <p className="text-sm text-navy-textSecondary dark:text-navyDark-textSecondary">
+            Try a different search term, year, or season.
+          </p>
+        </div>
       ) : (
         <>
           {!loading && hasNextPage && (


### PR DESCRIPTION
…lution

GitHub's web merge editor picked the wrong side of a conflict in page.tsx, leaving an unimported MUI Typography component that broke the TS build.